### PR TITLE
Set the filename jade option in order to make logs more consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ JadeFilter.prototype.constructor = JadeFilter;
 JadeFilter.prototype.extensions = ['jade'];
 JadeFilter.prototype.targetExtension = 'html';
 
-JadeFilter.prototype.processString = function (str) {
+JadeFilter.prototype.processString = function (str, filename) {
+	this.options.filename = filename;
 	return jade.compile(str, this.options)(this.options.data);
 };
 


### PR DESCRIPTION
Logs like `Warning: missing space before text for line 3 of jade file "undefined"` are more consistent with the filename in order to debug.
